### PR TITLE
Support for RequireJS and as a standalone library.

### DIFF
--- a/src/lib/view.coffee
+++ b/src/lib/view.coffee
@@ -55,7 +55,7 @@ class View
 
 if typeof define == 'function' && define.amd
   define ->
-    View
+    {View}
 else if typeof module isnt 'undefined' and module.exports
   module.exports = {View}
 else

--- a/src/lib/view.coffee
+++ b/src/lib/view.coffee
@@ -53,4 +53,10 @@ class View
 		@$el.remove()
 		@
 
-module.exports = {View}
+if typeof define == 'function' && define.amd
+  define ->
+    View
+else if typeof module isnt 'undefined' and module.exports
+  module.exports = {View}
+else
+  this.View = View


### PR DESCRIPTION
Miniview currently only supports module loaders supporting CommonJS.
This excludes its use as a standalone library (attach to the global
space) or with AMD loaders such as RequireJS. This patch makes
`miniview` support all three approaches.
